### PR TITLE
display: Fixes dimensions used when displaying charging icon

### DIFF
--- a/LilyGO-T-Wristband.ino
+++ b/LilyGO-T-Wristband.ino
@@ -453,9 +453,9 @@ void loop()
     if (charge_indication) {
         charge_indication = false;
         if (digitalRead(CHARGE_PIN) == LOW) {
-            tft.pushImage(140, 55, 34, 16, charge);
+            tft.pushImage(140, 55, 17, 32, charge);
         } else {
-            tft.fillRect(140, 55, 34, 16, TFT_BLACK);
+            tft.fillRect(140, 55, 17, 32, TFT_BLACK);
         }
     }
 


### PR DESCRIPTION
The charging lightening bolt is not displayed correctly as the size is
incorrect. This patch allows the lightening bolt to be displayed.